### PR TITLE
allow DOCTYPE declaration

### DIFF
--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/CoberturaSourceReportFactory.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/CoberturaSourceReportFactory.groovy
@@ -16,6 +16,9 @@ class CoberturaSourceReportFactory implements SourceReportFactory {
 		// skip external DTD validation
 		// see http://xerces.apache.org/xerces2-j/features.html#nonvalidating.load-external-dtd
 		parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+		// allow DOCTYPE declaration
+		// see http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl
+		parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
 
 		// parse
 		Node coverage = parser.parse(file)


### PR DESCRIPTION
see http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl

example for breaking build due to doctype checking: https://travis-ci.org/gesellix-docker/gradle-docker-plugin/builds/27949346
