### PR TITLE
Added Android Plugin support. Pulls in the Main Source.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile localGroovy()
     compile gradleApi()
 
+    compile 'com.android.tools.build:gradle:0.11.+'
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
     compile 'org.apache.httpcomponents:httpmime:4.3'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.4.1
+version=0.4.2-SNAPSHOT
 group=org.kt3k.gradle.plugin

--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
@@ -1,5 +1,6 @@
 package org.kt3k.gradle.plugin.coveralls.domain
 
+import com.android.build.gradle.BasePlugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaPlugin
@@ -23,6 +24,10 @@ class JacocoSourceReportFactory implements SourceReportFactory {
 	static List<File> createTargetSrcDirs(Project project) {
 
 		List<File> targetSrcDirs = new ArrayList<File>()
+
+        project.plugins.withType(BasePlugin) {
+            targetSrcDirs += project.android.sourceSets.main.java.getSrcDirs()
+        }
 
 		project.plugins.withType(JavaPlugin) {
 			targetSrcDirs += project.sourceSets.main.java.srcDirs


### PR DESCRIPTION
This uses the Main `sourceSet` of the Android plugins (Android/Library) they both inherit from the BasePlugin now.

This _shouldn't_ be nessary, but setting https://github.com/kt3k/coveralls-gradle-plugin/blob/master/src/main/groovy/org/kt3k/gradle/plugin/CoverallsPluginExtension.groovy#L26 has no effect on the `project.extentions.coveralls.sourceSets` property.

If you fix that then, this becomes slightly obsolete.
