### PR TITLE
Fix Android plugins not detected

### DIFF
--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
@@ -23,7 +23,17 @@ class JacocoSourceReportFactory implements SourceReportFactory {
 
 		List<File> targetSrcDirs = new ArrayList<File>()
 
-		project.plugins.matching { it.class.name == "com.android.build.gradle.BasePlugin" }.all {
+		project.plugins.matching {
+			def instanceofWithName
+			instanceofWithName = { Class c, name ->
+				if (c == Object.class) {
+					false
+				} else {
+					c.name == name || instanceofWithName(c.superclass, name)
+				}
+			}
+			instanceofWithName(it.class, "com.android.build.gradle.BasePlugin")
+		}.all {
 			targetSrcDirs += project.android.sourceSets.main.java.getSrcDirs()
 		}
 


### PR DESCRIPTION
Hi,
I’m developing some Android libraries and I'm using this plugin, but I have a problem.

gradle-android-plugin 0.13.x (released on this September) requires Gradle 2.1,
so I thought that coveralls-gradle-plugin v2.0.0 (supports Gradle 2.x) will work… but it doesn’t:

```
:
No source file found on the project: “myProject"
With coverage file: /path/to/myProject/build/outputs/reports/coverage/debug/report.xml
```

The cause is 82ad4e27.
This ignores Android plugins which are extending `BasePlugin` such as `AppPlugin` and `LibraryPlugin`.

``` groovy
// This code correctly handles subclasses of BasePlugin
project.plugins.withType(BasePlugin) {

// This doesn’t… this only see the plugin class EQUALS to the BasePlugin
project.plugins.matching { it.class.name == "com.android.build.gradle.BasePlugin" }.all {
```

I made a fix for this.

For Android App/Library projects,
- gradle-android-plugin 0.12.x requires Gradle 1.10+ (which works well with coveralls-gradle-plugin v1.0.2),
- gradle-android-plugin 0.13.x requires Gradle 2.1+ (which works well with coveralls-gradle-plugin v2.0.0 + this fix).
