### PR TITLE
Add tests for Android plugin detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # gradle build dir
-build
+build/*
+!build/gradle
 
 # gradle local dir
 .gradle

--- a/src/test/groovy/com/android/build/gradle/BasePlugin.groovy
+++ b/src/test/groovy/com/android/build/gradle/BasePlugin.groovy
@@ -1,0 +1,19 @@
+package com.android.build.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+// This plugin and other plugins in this package
+// are fake classes for the real Android plugins(com.android.tools.build:gradle).
+// The real one checks runtime Gradle version in the apply method,
+// which makes this project incompatible.
+class BasePlugin implements Plugin<Project> {
+
+	@Override
+	void apply(Project project) {
+		if (project.extensions.findByName('android') == null) {
+			project.extensions.create('android', DummyAndroidExtension)
+		}
+	}
+
+}

--- a/src/test/groovy/com/android/build/gradle/DummyAndroidExtension.groovy
+++ b/src/test/groovy/com/android/build/gradle/DummyAndroidExtension.groovy
@@ -1,0 +1,26 @@
+package com.android.build.gradle
+
+// this extension is made for avoiding compile error in
+// project.android.sourceSets.main.java.getSrcDirs()
+class DummyAndroidExtension {
+
+	DummyAndroidExtension getSourceSets() {
+		return this
+	}
+
+	DummyAndroidExtension getMain() {
+		return this
+	}
+
+	DummyAndroidExtension getJava() {
+		return this
+	}
+
+	List<File> getSrcDirs() {
+		// to check if this plugin is detected,
+		// this method should return some files
+		List<File> dirs = new ArrayList<File>()
+		dirs += new File("whatever")
+	}
+
+}

--- a/src/test/groovy/com/android/build/gradle/DummyAndroidPlugin.groovy
+++ b/src/test/groovy/com/android/build/gradle/DummyAndroidPlugin.groovy
@@ -1,0 +1,8 @@
+package com.android.build.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+// this plugin extends the BasePlugin and it should be detected
+class DummyAndroidPlugin extends BasePlugin implements Plugin<Project> {
+}

--- a/src/test/groovy/com/android/build/gradle/DummyExtendedAndroidPlugin.groovy
+++ b/src/test/groovy/com/android/build/gradle/DummyExtendedAndroidPlugin.groovy
@@ -1,0 +1,8 @@
+package com.android.build.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+// this plugin extends a subclass of BasePlugin and it should be detected
+class DummyExtendedAndroidPlugin extends DummyAndroidPlugin implements Plugin<Project> {
+}

--- a/src/test/groovy/com/android/build/gradle/DummyExtendedPlugin.groovy
+++ b/src/test/groovy/com/android/build/gradle/DummyExtendedPlugin.groovy
@@ -1,0 +1,13 @@
+package com.android.build.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+// this plugin extends a plugin but not the BasePlugin
+class DummyExtendedPlugin extends DummyPlugin implements Plugin<Project> {
+
+	@Override
+	void apply(Project project) {
+	}
+
+}

--- a/src/test/groovy/com/android/build/gradle/DummyPlugin.groovy
+++ b/src/test/groovy/com/android/build/gradle/DummyPlugin.groovy
@@ -1,0 +1,13 @@
+package com.android.build.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+// this plugin does NOT extend BasePlugin
+class DummyPlugin implements Plugin<Project> {
+
+	@Override
+	void apply(Project project) {
+	}
+
+}

--- a/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
+++ b/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
@@ -1,5 +1,10 @@
 package org.kt3k.gradle.plugin.coveralls.domain
 
+import com.android.build.gradle.BasePlugin
+import com.android.build.gradle.DummyAndroidPlugin
+import com.android.build.gradle.DummyExtendedAndroidPlugin
+import com.android.build.gradle.DummyExtendedPlugin
+import com.android.build.gradle.DummyPlugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaPlugin
@@ -70,6 +75,30 @@ class JacocoSourceReportFactoryTest {
 		List<SourceReport> reports = new JacocoSourceReportFactory().createReportList(project, new File('src/test/fixture/jacocoTestReport.xml'))
 
 		assertNotNull(reports)
+	}
+
+
+	@Test
+	public void testCreateReportForAndroidPlugin() throws Exception {
+
+		// should NOT be detected
+		project.plugins.apply(DummyPlugin)
+		project.plugins.apply(DummyExtendedPlugin)
+
+		List<File> srcDirs = JacocoSourceReportFactory.createTargetSrcDirs(project)
+
+		assertEquals 0, srcDirs.size()
+
+		// should be detected
+		project.plugins.apply(BasePlugin)
+		project.plugins.apply(DummyAndroidPlugin)
+		project.plugins.apply(DummyExtendedAndroidPlugin)
+
+		srcDirs = JacocoSourceReportFactory.createTargetSrcDirs(project)
+
+		// if we can apply the real Android plugins in the future,
+		// we might have to check the contents of srcDirs
+		assertEquals 3, srcDirs.size()
 	}
 
 


### PR DESCRIPTION
Added test codes for detecting Android Plugins (which I wrote in #25).

Android plugin checks Gradle version in `BasePlugin#apply()`
and if it’s not applied on supported versions, `BuildException` will be thrown.

| `gradle-android-plugin` | required on `apply()` |
| --- | --- |
| `< v0.12` | Gradle 1.10+ |
| `>= v0.13` | Gradle 2.1+ |

So I wrote some fake plugins just for testing the target codes.

If `coveralls-gradle-plugin` supports Gradle 2.1 in the future, these test codes should be replaced.

Sorry for dropping the coverage eventually
but I don’t know why Covertura judges that some codes are not covered.
I think they are actually tested.
(I mean, `c.name == name || instanceofWithName(c.superclass, name)`
in `JacocoSourceReportFactory#createTargetSrcDirs()`)

Thanks!
