### PR TITLE
Also use the pull request environment variable from Snap CI

### DIFF
--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactory.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactory.groovy
@@ -61,6 +61,7 @@ class ServiceInfoFactory {
                         serviceNumber: env.get('SNAP_PIPELINE_COUNTER'),
                         serviceBranch: env.get('SNAP_BRANCH'),
                         repoToken: env.get('COVERALLS_REPO_TOKEN'),
+                        servicePullRequest: env.get('SNAP_PULL_REQUEST_NUMBER'),
                         environment: [
                                 'pipeline_counter': env.get('SNAP_PIPELINE_COUNTER'),
                                 'stage_name'      : env.get('SNAP_STAGE_NAME'),

--- a/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactoryTest.groovy
+++ b/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactoryTest.groovy
@@ -73,13 +73,15 @@ class ServiceInfoFactoryTest {
                 COVERALLS_REPO_TOKEN: 'ABCDEF',
                 SNAP_BRANCH: "branchX",
                 SNAP_STAGE_NAME: "test",
-                SNAP_COMMIT: "231asdfadsf424"
+                SNAP_COMMIT: "231asdfadsf424",
+                SNAP_PULL_REQUEST_NUMBER: "42"
         )
 
         assertEquals 'snapci', serviceInfo.serviceName
         assertEquals '12345678', serviceInfo.serviceNumber
         assertEquals 'branchX', serviceInfo.serviceBranch
         assertEquals 'ABCDEF', serviceInfo.repoToken
+        assertEquals '42', serviceInfo.servicePullRequest
 
         assertEquals '12345678', serviceInfo.environment['pipeline_counter']
         assertEquals 'test', serviceInfo.environment['stage_name']


### PR DESCRIPTION
Small improvement on CV's [pull request](https://github.com/kt3k/coveralls-gradle-plugin/pull/35) for Snap CI. Not it will also look for the pull request specific environment variable.