### PR TITLE
Remove redundant environment configs from usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ language: java
 jdk:
 - oraclejdk7
 
-env:
-- TERM=dumb
-
 after_success:
 - ./gradlew cobertura coveralls
 ```
@@ -94,9 +91,6 @@ language: java
 
 jdk:
 - oraclejdk7
-
-env:
-- TERM=dumb
 
 after_success:
 - ./gradlew jacocoTestReport coveralls


### PR DESCRIPTION
No need to set  `TERM=dump` explicitly, it's already set by default for JVM based builds.

See: travis-ci/travis-build#240