### PR TITLE
Add bitrise ci support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The following CI services should *automatically* work:
  - [Travis CI](https://travis-ci.org/)
  - [CircleCI](https://circleci.com/)
  - [Jenkins CI](http://jenkins-ci.org/)
+ - [Bitrise CI](https://bitrise.io/)
 
 If you need to customize something or support a different CI service, you can configure environment variables:
 
@@ -146,6 +147,7 @@ If you need to customize something or support a different CI service, you can co
  * CircleCI: `circleci`
  * Jenkins: `jenkins`
  * Snap CI: `snapci`
+ * Bitrise CI: `bitrise`
 
 If you have `COVERALLS_REPO_TOKEN` set and you're using Travis-CI not Travis-Pro, you need to set `CI_NAME=travis-ci`.
 

--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactory.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactory.groovy
@@ -68,6 +68,18 @@ class ServiceInfoFactory {
                                 'branch'          : env.get('SNAP_BRANCH'),
                                 'commit_sha'      : env.get('SNAP_COMMIT')]
                 )
+            } else if (envIsBitrise(env)) {
+                return new ServiceInfo(
+                        serviceName: 'bitrise',
+                        serviceNumber: env.get('BITRISE_BUILD_NUMBER'),
+                        serviceBuildUrl: env.get('BITRISE_BUILD_URL'),
+                        serviceBranch: env.get('BITRISE_GIT_BRANCH'),
+                        servicePullRequest: env.get('BITRISE_PULL_REQUEST'),
+                        repoToken: env.get('COVERALLS_REPO_TOKEN'),
+                        environment: [
+                                'branch'    : env.get('BITRISE_GIT_BRANCH'),
+                                'commit_sha': env.get('BITRISE_GIT_COMMIT')]
+                )
             } else {
                 return new ServiceInfo(
                         serviceName: env['CI_NAME'] ?: 'other',
@@ -108,6 +120,10 @@ class ServiceInfoFactory {
 
     private static boolean envIsSnap(Map<String, String> env) {
         env.get('SNAP_CI') == 'true'
+    }
+
+    private static boolean envIsBitrise(Map<String, String> env) {
+        env.get('BITRISE_BUILD_URL') != null
     }
 
     private static boolean repoTokenIsSet(Map<String, String> env) {

--- a/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactoryTest.groovy
+++ b/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactoryTest.groovy
@@ -109,6 +109,28 @@ class ServiceInfoFactoryTest {
     }
 
     @Test
+    void testCreateFromEnvVarBitrise() {
+        // test the case of bitrise
+        ServiceInfo serviceInfo = ServiceInfoFactory.createFromEnvVar(
+                BITRISE_BUILD_NUMBER: "123456789",
+                BITRISE_BUILD_URL: "https://www.bitrise.io/build/1234567890abcdef",
+                BITRISE_GIT_BRANCH: "branchX",
+                BITRISE_GIT_COMMIT: "231asdfadsf424",
+                BITRISE_PULL_REQUEST: "11",
+                COVERALLS_REPO_TOKEN: 'ABCDEF',
+        )
+
+        assertEquals 'bitrise', serviceInfo.serviceName
+        assertEquals '123456789', serviceInfo.serviceNumber
+        assertEquals 'branchX', serviceInfo.serviceBranch
+        assertEquals 'ABCDEF', serviceInfo.repoToken
+        assertEquals '11', serviceInfo.servicePullRequest
+
+        assertEquals 'branchX', serviceInfo.environment['branch']
+        assertEquals '231asdfadsf424', serviceInfo.environment['commit_sha']
+    }
+
+    @Test
     void testCreateFromEnvVarJenkinsNonPullRequest() {
         // test the case of travis-pro
         ServiceInfo serviceInfo = ServiceInfoFactory.createFromEnvVar(


### PR DESCRIPTION
I've tested changes locally and I'm getting the same [error]( 
https://github.com/kt3k/coveralls-gradle-plugin/issues/27)
`> org.apache.http.entity.mime.content.ByteArrayBody.<init>([BLorg/apache/http/entity/ContentType;Ljava/lang/String;)V`.

Testing process:
1) I'm updating plugin version in gradle.properties
2) Publishing modified plugin version (2.5.0 for ex.) using command `./gradlew publishToMavenLocal`
3) Switching to AS and modifying dependencies
```
buildscript {
    repositories {
        jcenter()
        mavenLocal()
    }
    dependencies {
        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.5.0'
    }
}
```
4) Executing coveralls task `./gradlew coveralls` and getting error
```
* What went wrong:
Execution failed for task ':app:coveralls'.
> org.apache.http.entity.mime.content.ByteArrayBody.<init>([BLorg/apache/http/entity/ContentType;Ljava/lang/String;)V

* Try:
Run with --info or --debug option to get more log output.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':app:coveralls'.
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:69)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:46)
        at org.gradle.api.internal.tasks.execution.PostExecutionAnalysisTaskExecuter.execute(PostExecutionAnalysisTaskExecuter.java:35)
        at org.gradle.api.internal.tasks.execution.SkipUpToDateTaskExecuter.execute(SkipUpToDateTaskExecuter.java:64)
        at org.gradle.api.internal.tasks.execution.ValidatingTaskExecuter.execute(ValidatingTaskExecuter.java:58)
        at org.gradle.api.internal.tasks.execution.SkipEmptySourceFilesTaskExecuter.execute(SkipEmptySourceFilesTaskExecuter.java:42)
        at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:52)
        at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:53)
        at org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter.execute(ExecuteAtMostOnceTaskExecuter.java:43)
        at org.gradle.api.internal.AbstractTask.executeWithoutThrowingTaskFailure(AbstractTask.java:310)
        at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.executeTask(AbstractTaskPlanExecutor.java:79)
        at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.processTask(AbstractTaskPlanExecutor.java:63)
        at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.run(AbstractTaskPlanExecutor.java:51)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:54)
        at org.gradle.internal.concurrent.StoppableExecutorImpl$1.run(StoppableExecutorImpl.java:40)
Caused by: java.lang.NoSuchMethodError: org.apache.http.entity.mime.content.ByteArrayBody.<init>([BLorg/apache/http/entity/ContentType;Ljava/lang/String;)V
        at org.apache.http.entity.mime.MultipartEntityBuilder.addBinaryBody(MultipartEntityBuilder.java:131)
        at org.apache.http.entity.mime.MultipartEntityBuilder$addBinaryBody$0.call(Unknown Source)
        at org.kt3k.gradle.plugin.coveralls.CoverallsTask$_postJsonToUrl_closure1.doCall(CoverallsTask.groovy:44)
        at groovyx.net.http.HTTPBuilder.doRequest(HTTPBuilder.java:432)
        at groovyx.net.http.HTTPBuilder.request(HTTPBuilder.java:366)
        at groovyx.net.http.HTTPBuilder$request.call(Unknown Source)
        at org.kt3k.gradle.plugin.coveralls.CoverallsTask.postJsonToUrl(CoverallsTask.groovy:42)
        at org.kt3k.gradle.plugin.coveralls.CoverallsTask$postJsonToUrl$0.callCurrent(Unknown Source)
        at org.kt3k.gradle.plugin.coveralls.CoverallsTask.coverallsAction(CoverallsTask.groovy:152)
        at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:75)
        at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$StandardTaskAction.doExecute(AnnotationProcessingTaskFactory.java:226)
        at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$StandardTaskAction.execute(AnnotationProcessingTaskFactory.java:219)
        at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$StandardTaskAction.execute(AnnotationProcessingTaskFactory.java:208)
        at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:589)
        at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:572)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:80)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:61)
        ... 14 more
```

But, if I switch to `2.4.0x` version and execute `coveralls` task in AS in the same project - it works fine.

It's a bit weird, as I didn't change dependencies versions in plugin.

Probably, I'm doing local plugin test in a wrong way.
