### PR TITLE
Populate CircleCI pull request field

### DIFF
--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactory.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactory.groovy
@@ -28,6 +28,7 @@ class ServiceInfoFactory {
                         serviceName: 'circleci',
                         serviceNumber: env.get('CIRCLE_BUILD_NUM'),
                         repoToken: env.get('COVERALLS_REPO_TOKEN'),
+                        servicePullRequest: env.get('CI_PULL_REQUEST'),
                         environment: [
                                 'circleci_build_num': env.get('CIRCLE_BUILD_NUM'),
                                 'branch'            : env.get('CIRCLE_BRANCH'),

--- a/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactoryTest.groovy
+++ b/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/ServiceInfoFactoryTest.groovy
@@ -72,12 +72,14 @@ class ServiceInfoFactoryTest {
                 CIRCLECI: 'true',
                 CIRCLE_BUILD_NUM: '12345678',
                 COVERALLS_REPO_TOKEN: 'ABCDEF',
+                CI_PULL_REQUEST: 'pullrequest111',
                 CIRCLE_BRANCH: 'branchX',
                 CIRCLE_SHA1: '231asdfadsf424')
 
         assertEquals 'circleci', serviceInfo.serviceName
         assertEquals '12345678', serviceInfo.serviceNumber
         assertEquals 'ABCDEF', serviceInfo.repoToken
+        assertEquals 'pullrequest111', serviceInfo.servicePullRequest
         assertEquals 'branchX', serviceInfo.environment['branch']
         assertEquals '231asdfadsf424', serviceInfo.environment['commit_sha']
         assertEquals '12345678', serviceInfo.environment['circleci_build_num']


### PR DESCRIPTION
This allows Coveralls to post back to GitHub with a status check.