### PR TITLE
Force JDK7 compatibility in Java/Groovy compile tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,16 @@ dependencies {
     testCompile 'com.github.tomakehurst:wiremock:1.18'
 }
 
+tasks.withType(JavaCompile) {
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+}
+
+tasks.withType(GroovyCompile) {
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+}
+
 jacocoTestReport {
     reports {
         xml.enabled true


### PR DESCRIPTION
Regression in `2.7.0` as binaries target JDK8 by default.

Fix for #54 