### PR TITLE
Count line hits for PIT correctly

### DIFF
--- a/src/test/fixture/mutations.xml
+++ b/src/test/fixture/mutations.xml
@@ -88,4 +88,15 @@
     <killingTest>org.kt3k.bankaccount.TransferContextTest.testTransfer(org.kt3k.bankaccount.TransferContextTest)</killingTest>
     <description>removed call to org/kt3k/bankaccount/BankAccount::increase</description>
   </mutation>
+  <mutation detected='true' status='TIMED_OUT'>
+    <sourceFile>TransferContext.java</sourceFile>
+    <mutatedClass>org.kt3k.bankaccount.TransferContext$BankAccountReceiver</mutatedClass>
+    <mutatedMethod>onReceive</mutatedMethod>
+    <methodDescription>(Ljava/lang/Integer;)V</methodDescription>
+    <lineNumber>37</lineNumber>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+    <index>24</index>
+    <killingTest/>
+    <description>removed call to org/kt3k/bankaccount/BankAccount::increase</description>
+  </mutation>
 </mutations>

--- a/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/PITSourceReportFactoryTest.groovy
+++ b/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/PITSourceReportFactoryTest.groovy
@@ -33,9 +33,11 @@ class PITSourceReportFactoryTest {
 
 		assertEquals 'src/test/fixture/org/kt3k/bankaccount/BankAccount.java', reports[0].name
 		assertEquals 30, reports[0].coverage.size()
-		assertEquals 4, reports[0].coverage.findAll{ it != null }.sum()
+		assertEquals 4, reports[0].coverage.findAll{ it != null }.size()
+		assertEquals 3, reports[0].coverage.findAll{ it != null }.sum()
 		assertEquals 'src/test/fixture/org/kt3k/bankaccount/TransferContext.java', reports[1].name
 		assertEquals 45, reports[1].coverage.size()
+		assertEquals 4, reports[1].coverage.findAll{ it != null }.size()
 		assertEquals 4, reports[1].coverage.findAll{ it != null }.sum()
 	}
 


### PR DESCRIPTION
Only killed mutations count as hits, and only lived or uncovered mutations
count as misses.