### PR TITLE
Add configuration options section for JaCoCo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ after_success:
 - ./gradlew jacocoTestReport coveralls
 ```
 
+Configuration Options
+```
+coveralls {
+    jacocoReportPath 'build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml'
+}
+```
+
 ### Use with [*pitest*](https://github.com/szpak/gradle-pitest-plugin) plugin
 
 Add the following lines to build.gradle:


### PR DESCRIPTION
For JaCoCo usage, we have an option to configure the report path in case it's not in the default location.

Addresses documentation issue that led to Issue #37 