### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: groovy
 jdk:
 - oraclejdk8
 
+script:
+- ./gradlew -Dscan=true build
+
 after_success:
 - ./gradlew check jacocoTestReport coveralls
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "com.gradle.build-scan" version "1.16"
     id "groovy"
     id "maven"
     id "eclipse"
@@ -8,6 +9,11 @@ plugins {
     id "jacoco"
     id "com.jfrog.bintray" version "1.4"
     id "com.github.kt3k.coveralls" version "2.5.0"
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 group 'org.kt3k.gradle.plugin'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.