### PR TITLE
Add missing input to task "test"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,3 +68,7 @@ buildScan {
     termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
     termsOfServiceAgree = 'yes'
 }
+
+test {
+    inputs.dir "$projectDir/src/test/fixture"
+}


### PR DESCRIPTION
Hi

This pull request fixes the incremental task test.
Beyond test code, this task depends on some test resources included in the `src/test/fixture` directory. However, this directory is not declared as input to this task, so tests  are not executed whenever there are updates to any of those dependent  files.

This commit fixes this issue by declaring `src/test/fixture` as input of task test.


