### PR TITLE
add kotlin root package directory support

### DIFF
--- a/src/main/groovy/org/kt3k/gradle/plugin/CoverallsPluginExtension.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/CoverallsPluginExtension.groovy
@@ -16,6 +16,9 @@ class CoverallsPluginExtension {
 	/** API endpoint of Coveralls */
 	String apiEndpoint = 'https://coveralls.io/api/v1/jobs'
 
+	/** Kotlin root package */
+	String kotlinRootPackage = ''
+
 	/** Jacoco report path */
 	Object jacocoReportPath = 'build/reports/jacoco/test/jacocoTestReport.xml'
 

--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
@@ -25,18 +25,25 @@ class JacocoSourceReportFactory implements SourceReportFactory {
 
 		List<File> targetSrcDirs = new ArrayList<File>()
 
-		project.plugins.matching {
-			def instanceofWithName
-			instanceofWithName = { Class c, name ->
-				if (c == Object.class) {
-					false
-				} else {
-					c.name == name || instanceofWithName(c.superclass, name)
-				}
+	def instanceofWithName
+		instanceofWithName = { Class c, name ->
+			if (c == Object.class) {
+				false
+			} else {
+				c.name == name || instanceofWithName(c.superclass, name)
 			}
+		}
+
+		project.plugins.matching {
 			instanceofWithName(it.class, "com.android.build.gradle.BasePlugin")
 		}.all {
 			targetSrcDirs += project.android.sourceSets.main.java.getSrcDirs()
+		}
+
+		project.plugins.matching {
+			instanceofWithName(it.class, "org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper")
+			}.all {
+			targetSrcDirs += project.sourceSets.main.kotlin.srcDirs
 		}
 
 		project.plugins.withType(JavaPlugin) {

--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
@@ -15,7 +15,9 @@ class JacocoSourceReportFactory implements SourceReportFactory {
 
 		List<File> targetSrcDirs = createTargetSrcDirs(project)
 
-		return createReportList(targetSrcDirs.sort(), jacocoReportFile)
+		String kotlinRootPackage = project.extensions.coveralls.kotlinRootPackage.trim()
+
+		return createReportList(kotlinRootPackage, targetSrcDirs.sort(), jacocoReportFile)
 
 	}
 
@@ -52,9 +54,12 @@ class JacocoSourceReportFactory implements SourceReportFactory {
 		return project.extensions.coveralls.sourceDirs + targetSrcDirs.sort()
 	}
 
-	static List<SourceReport> createReportList(List<File> srcDirs, File jacocoReportFile) {
+	static List<SourceReport> createReportList(String kotlinRootPackage, List<File> srcDirs, File jacocoReportFile) {
 		// create parser
 		XmlParser parser = new XmlParserFactory().xmlParser
+
+		// transform to path
+		kotlinRootPackage = kotlinRootPackage.replace('.', '/')
 
 		// parse
 		Node report = parser.parse(jacocoReportFile)
@@ -84,6 +89,10 @@ class JacocoSourceReportFactory implements SourceReportFactory {
 		// find actual source files
 		// and create the list of SourceReport instances
 		a.each { String filename, Map<Integer, Integer> cov ->
+
+			if (!kotlinRootPackage.isEmpty()) {
+				filename = filename.replaceFirst("^${kotlinRootPackage}/", "")
+			}
 
 			File sourceFile = srcDirs.collect { new File(it, filename) }.find { it.exists() }
 

--- a/src/test/fixture/srcKotlin/CoverallsPlugin.groovy
+++ b/src/test/fixture/srcKotlin/CoverallsPlugin.groovy
@@ -1,0 +1,21 @@
+package org.kt3k.gradle.plugin
+
+import org.gradle.api.*
+
+import org.slf4j.LoggerFactory
+
+import org.kt3k.gradle.plugin.coveralls.Application
+
+class CoverallsPlugin implements Plugin<Project> {
+
+	static String API_ENDPOINT = 'https://coveralls.io/api/v1/jobs'
+
+	static String COBERTURA_REPORT_PATH = 'build/reports/cobertura/coverage.xml'
+
+	void apply(Project project) {
+		project.task('coveralls') << {
+			Application.main(System.getenv(), API_ENDPOINT, COBERTURA_REPORT_PATH, LoggerFactory.getLogger('coveralls-logger'))
+		}
+	}
+
+}

--- a/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/BaseKotlinPlugin.groovy
+++ b/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/BaseKotlinPlugin.groovy
@@ -1,0 +1,36 @@
+package org.jetbrains.kotlin.gradle.plugin
+
+import org.codehaus.groovy.runtime.InvokerHelper
+import org.gradle.api.Action
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.Convention
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.SourceSet
+
+// This plugin and other plugins in this package
+// are fake classes for the real Kotlin plugins(org.jetbrains.kotlin.jvm).
+class KotlinPluginWrapper implements Plugin<Project> {
+
+	private class KotlinSourceSet {
+		SourceSet kotlin = new SourceSet()
+
+		class SourceSet {
+			List<File> getSrcDirs() {
+				return [new File("src/main/kotlin")]
+			}
+		}
+	}
+
+	@Override
+	void apply(Project project) {
+		project.getPluginManager().apply(JavaPlugin.class)
+		((JavaPluginConvention)project.getConvention().getPlugin(JavaPluginConvention.class)).getSourceSets().all(new Action<SourceSet>() {
+			void execute(SourceSet sourceSet) {
+				Convention sourceSetConvention = (Convention)InvokerHelper.getProperty(sourceSet, "convention")
+				sourceSetConvention.getPlugins().put("kotlin", new KotlinSourceSet())
+			}
+		})
+	}
+}

--- a/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
+++ b/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
@@ -10,6 +10,7 @@ import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.scala.ScalaPlugin
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.junit.Test
 import org.junit.Before
 import org.kt3k.gradle.plugin.CoverallsPluginExtension
@@ -148,7 +149,7 @@ class JacocoSourceReportFactoryTest {
 			'org.kt3k.gradle.plugin',
 			[new File('src/test/fixture/srcKotlin')],
 			new File('src/test/fixture/jacocoTestReport.xml')
-        )
+		)
 
 		assertNotNull reports
 
@@ -158,5 +159,16 @@ class JacocoSourceReportFactoryTest {
 		reports.sort { it.name }
 
 		assertEquals 'src/test/fixture/srcKotlin/CoverallsPlugin.groovy', reports[0].name
-    }
+	}
+
+	@Test
+	public void testCreateReportForKotlinProject2() throws Exception {
+		project.plugins.apply(KotlinPluginWrapper)
+
+		List<File> srcDirs = JacocoSourceReportFactory.createTargetSrcDirs(project)
+
+		srcDirs.each {
+			assertTrue it.absolutePath.endsWith("src" + separatorChar + "main" + separatorChar + "java") || it.absolutePath.endsWith('src' + separatorChar + 'main' + separatorChar + 'kotlin')
+		}
+	}
 }

--- a/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
+++ b/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
@@ -144,7 +144,7 @@ class JacocoSourceReportFactoryTest {
 	@Test
 	public void testCreateReportForKotlinProject() throws Exception {
 		// test with single (not multi) project jacoco report
-		List<SourceReport> reports = new JacocoSourceReportFactory().createReportList(
+		List<SourceReport> reports = JacocoSourceReportFactory.createReportList(
 			'org.kt3k.gradle.plugin',
 			[new File('src/test/fixture/srcKotlin')],
 			new File('src/test/fixture/jacocoTestReport.xml')

--- a/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
+++ b/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
@@ -34,7 +34,7 @@ class JacocoSourceReportFactoryTest {
 	@Test
 	public void testCreateReport() throws Exception {
 		// test with single (not multi) project jacoco report
-		List<SourceReport> reports = JacocoSourceReportFactory.createReportList([new File('src/test/fixture')], new File('src/test/fixture/jacocoTestReport.xml'))
+		List<SourceReport> reports = JacocoSourceReportFactory.createReportList('', [new File('src/test/fixture')], new File('src/test/fixture/jacocoTestReport.xml'))
 
 		assertNotNull reports
 
@@ -55,7 +55,7 @@ class JacocoSourceReportFactoryTest {
 	@Test
 	public void testCreateReportWithMultiProjectReport() {
 		// test with multi-project jacoco report
-		List<SourceReport> reports = JacocoSourceReportFactory.createReportList([new File('src/test/fixture')], new File('src/test/fixture/jacocoReportWithMultipleGroups.xml'))
+		List<SourceReport> reports = JacocoSourceReportFactory.createReportList('', [new File('src/test/fixture')], new File('src/test/fixture/jacocoReportWithMultipleGroups.xml'))
 
 		assertNotNull reports
 
@@ -140,4 +140,23 @@ class JacocoSourceReportFactoryTest {
 			assertTrue it.absolutePath.endsWith("src" + separatorChar + "main" + separatorChar + "java") || it.absolutePath.endsWith('src' + separatorChar + 'main' + separatorChar + 'scala')
 		}
 	}
+
+	@Test
+	public void testCreateReportForKotlinProject() throws Exception {
+		// test with single (not multi) project jacoco report
+		List<SourceReport> reports = new JacocoSourceReportFactory().createReportList(
+			'org.kt3k.gradle.plugin',
+			[new File('src/test/fixture/srcKotlin')],
+			new File('src/test/fixture/jacocoTestReport.xml')
+        )
+
+		assertNotNull reports
+
+		assertEquals 1, reports.size()
+
+		// sort reports for assertion
+		reports.sort { it.name }
+
+		assertEquals 'src/test/fixture/srcKotlin/CoverallsPlugin.groovy', reports[0].name
+    }
 }


### PR DESCRIPTION
**Details**

Currently the coverage plugin does not take into account [kotlin-styled directory structure](https://kotlinlang.org/docs/reference/coding-conventions.html#directory-structure) where the package name and the filesystem need not match (the root package is omitted from the filesystem)

This PR adds a configuration parameter `kotlinRootPackage` to strip the file path of the common prefix.
  
  
**Usage**
```groovy
coveralls {
    kotlinRootPackage = 'org.doe.john'
}
```

EDIT: Also auto adds the kotlin source set if the [Kotlin Plugin](https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/main/resources/META-INF/gradle-plugins/kotlin.properties) is present on the project.

  
**Further Work**
~One could theoretically already add the kotlin source set if the config param is present, but I found it hard to test since the Kotlin plugin is itself not imported into the project. 
Have already implemented the code, and can add if someone can point me out to how to have the `project.sourceSets.main.kotlin` set within a test.~ 

Figured out the base kotlin plugin name.

  
**Fixes**
Possibly #63 