### PR TITLE
Better relativization of paths

### DIFF
--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactory.groovy
@@ -5,6 +5,8 @@ import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.scala.ScalaPlugin
 
+import java.nio.file.Path
+
 /**
  * Factory class of SourceReport for JaCoCo report file.
  */
@@ -15,7 +17,7 @@ class JacocoSourceReportFactory implements SourceReportFactory {
 
 		List<File> targetSrcDirs = createTargetSrcDirs(project)
 
-		return createReportList(targetSrcDirs.sort(), jacocoReportFile)
+		return createReportList(targetSrcDirs.sort(), jacocoReportFile, project.projectDir.toPath())
 
 	}
 
@@ -52,7 +54,7 @@ class JacocoSourceReportFactory implements SourceReportFactory {
 		return project.extensions.coveralls.sourceDirs + targetSrcDirs.sort()
 	}
 
-	static List<SourceReport> createReportList(List<File> srcDirs, File jacocoReportFile) {
+	static List<SourceReport> createReportList(List<File> srcDirs, File jacocoReportFile, Path basePath) {
 		// create parser
 		XmlParser parser = new XmlParserFactory().xmlParser
 
@@ -99,8 +101,7 @@ class JacocoSourceReportFactory implements SourceReportFactory {
 				r[line] = hits
 			}
 
-			// Compute relative path from . via https://gist.github.com/ysb33r/5804364
-			String relPath = new File('.').toURI().relativize( sourceFile.toURI() ).toString()
+			String relPath = basePath.toAbsolutePath().relativize(sourceFile.toPath().toAbsolutePath()).toString();
 			reports.add new SourceReport(relPath, source, r)
 		}
 

--- a/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
+++ b/src/test/groovy/org/kt3k/gradle/plugin/coveralls/domain/JacocoSourceReportFactoryTest.groovy
@@ -1,18 +1,16 @@
 package org.kt3k.gradle.plugin.coveralls.domain
 
-import com.android.build.gradle.BasePlugin
-import com.android.build.gradle.DummyAndroidPlugin
-import com.android.build.gradle.DummyExtendedAndroidPlugin
-import com.android.build.gradle.DummyExtendedPlugin
-import com.android.build.gradle.DummyPlugin
+import com.android.build.gradle.*
 import org.gradle.api.Project
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.scala.ScalaPlugin
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Test
 import org.junit.Before
+import org.junit.Test
 import org.kt3k.gradle.plugin.CoverallsPluginExtension
+
+import java.nio.file.Paths
 
 import static java.io.File.separatorChar
 import static org.junit.Assert.*
@@ -34,7 +32,7 @@ class JacocoSourceReportFactoryTest {
 	@Test
 	public void testCreateReport() throws Exception {
 		// test with single (not multi) project jacoco report
-		List<SourceReport> reports = JacocoSourceReportFactory.createReportList([new File('src/test/fixture')], new File('src/test/fixture/jacocoTestReport.xml'))
+		List<SourceReport> reports = JacocoSourceReportFactory.createReportList([new File('src/test/fixture')], new File('src/test/fixture/jacocoTestReport.xml'), Paths.get("."))
 
 		assertNotNull reports
 
@@ -55,7 +53,7 @@ class JacocoSourceReportFactoryTest {
 	@Test
 	public void testCreateReportWithMultiProjectReport() {
 		// test with multi-project jacoco report
-		List<SourceReport> reports = JacocoSourceReportFactory.createReportList([new File('src/test/fixture')], new File('src/test/fixture/jacocoReportWithMultipleGroups.xml'))
+		List<SourceReport> reports = JacocoSourceReportFactory.createReportList([new File('src/test/fixture')], new File('src/test/fixture/jacocoReportWithMultipleGroups.xml'), Paths.get("."))
 
 		assertNotNull reports
 


### PR DESCRIPTION
Use paths to relativize jacoco. Use project root as a base, instead of current dir

Current directory may be some daemon working dir, not a project one

This should fix: https://github.com/kt3k/coveralls-gradle-plugin/issues/100