### PR TITLE
Fix compatibility with Gradle 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following lines to build.gradle:
 
 ```groovy
 plugins {
-    id 'net.saliman.cobertura' version '2.3.1'
+    id 'net.saliman.cobertura' version '4.0.0'
     id 'com.github.kt3k.coveralls' version '2.10.2'
 }
 
@@ -82,7 +82,7 @@ Add the following lines to build.gradle:
 
 ```groovy
 plugins {
-    id "info.solidsoft.pitest" version '1.1.11'
+    id "info.solidsoft.pitest" version '1.6.0'
     id 'com.github.kt3k.coveralls' version '2.8.4'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ plugins {
     id "com.github.kt3k.coveralls" version "2.5.0"
 }
 
+apply from: 'gradle/funcTest.gradle'
+
 group 'org.kt3k.gradle.plugin'
 version '2.10.2'
 
@@ -23,6 +25,8 @@ dependencies {
     testImplementation 'junit:junit:4.11'
     testImplementation 'org.mockito:mockito-all:1.9.5'
     testImplementation 'com.github.tomakehurst:wiremock:2.23.2'
+
+    functionalTestImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 }
 
 tasks.withType(JavaCompile) {
@@ -42,6 +46,7 @@ jacocoTestReport {
 }
 
 gradlePlugin {
+  testSourceSets sourceSets.functionalTest
   plugins {
     coverallsPlugin {
       id = 'com.github.kt3k.coveralls'

--- a/gradle/funcTest.gradle
+++ b/gradle/funcTest.gradle
@@ -1,0 +1,33 @@
+
+sourceSets {
+    functionalTest {
+        groovy.srcDir file('src/funcTest/groovy')
+        resources.srcDir file('src/funcTest/resources')
+    }
+}
+
+dependencies {
+    functionalTestRuntimeOnly project(":")
+}
+
+configurations {
+    functionalTestImplementation.extendsFrom(testImplementation)
+    functionalTestRuntimeOnly.extendsFrom(testRuntimeOnly)
+}
+
+def functionalTest = tasks.register("functionalTest", Test) {
+    description = 'Runs the functional tests.'
+    group = 'verification'
+    testClassesDirs = sourceSets.functionalTest.output.classesDirs
+    classpath = sourceSets.functionalTest.runtimeClasspath
+    mustRunAfter test
+
+    reports {
+        html.destination = project.file("$html.destination/functional")
+        junitXml.destination = project.file("$junitXml.destination/functional")
+    }
+}
+
+tasks.named("check") {
+    dependsOn functionalTest
+}

--- a/src/funcTest/groovy/com/github/kt3k/coveralls/AbstractFunctionalTest.groovy
+++ b/src/funcTest/groovy/com/github/kt3k/coveralls/AbstractFunctionalTest.groovy
@@ -1,0 +1,108 @@
+package com.github.kt3k.coveralls
+
+import groovy.transform.CompileStatic
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+abstract class AbstractFunctionalTest extends Specification {
+
+    protected static final List<String> TESTED_COVERAGE_PLUGINS = [
+        new Plugin('pitest', "id 'info.solidsoft.pitest' version '1.6.0'", 'pitest', '''
+            pitest {
+                targetClasses = ['com.acme.*']
+            }
+        ''', '5.6'),
+        new Plugin('cobertura', "id 'net.saliman.cobertura' version '4.0.0'", 'cobertura'),
+        new Plugin('jacoco', "id 'jacoco'", 'jacocoTestReport')
+    ]
+
+    protected static final List<GradleVersion> TESTED_GRADLE_VERSIONS = [
+        GradleVersion.current(),
+        GradleVersion.version('6.8'),
+        GradleVersion.version('7.0-milestone-2'),
+    ]
+
+    @Rule
+    TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    private GradleVersion testedGradleVersion = GradleVersion.current()
+
+    private String noConfigurationCacheReason
+
+    protected void usingGradleVersion(GradleVersion gradleVersion) {
+        testedGradleVersion = gradleVersion
+    }
+
+    protected void withoutConfigurationCache(String reason) {
+        noConfigurationCacheReason = reason
+    }
+
+    File getProjectDir() {
+        temporaryFolder.root
+    }
+
+    File getBuildFile() {
+        file('build.gradle')
+    }
+
+    protected File file(String path) {
+        new File(projectDir, path)
+    }
+
+    private GradleRunner gradleRunner(List<String> arguments) {
+        GradleRunner.create()
+            .withGradleVersion(testedGradleVersion.version)
+            .forwardOutput()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments(arguments)
+    }
+
+    protected BuildResult build(String... arguments) {
+        gradleRunner(calculateArguments(arguments)).build()
+    }
+
+    protected BuildResult buildAndFail(String... arguments) {
+        gradleRunner(calculateArguments(arguments)).buildAndFail()
+    }
+
+    private List<String> calculateArguments(String... arguments) {
+        def gradleVersionWithConfigurationCache = testedGradleVersion >= GradleVersion.version('6.6')
+        if (gradleVersionWithConfigurationCache && noConfigurationCacheReason) {
+            println("Configuration cache disabled: $noConfigurationCacheReason")
+        }
+        (gradleVersionWithConfigurationCache && !noConfigurationCacheReason
+            ? ['--stacktrace',
+               '--configuration-cache',
+               // need to say to "warn" because for some reason the system property 'spock.iKnowWhatImDoing.disableGroovyVersionCheck'
+               // is leaking to the process under test as being read
+               '--configuration-cache-problems', 'warn']
+            : ['--stacktrace']) + (arguments as List)
+    }
+
+    @CompileStatic
+    protected static class Plugin {
+        final String name
+        final String pluginBlock
+        final String task
+        final String config
+        final GradleVersion minimalGradleVersion
+
+        Plugin(String name, String pluginBlock, String task, String configBlock = '', String minimalGradleVersion = GradleVersion.current().version) {
+            this.name = name
+            this.pluginBlock = pluginBlock
+            this.task = task
+            this.config = configBlock
+            this.minimalGradleVersion = GradleVersion.version(minimalGradleVersion)
+        }
+
+        @Override
+        String toString() {
+            name
+        }
+    }
+}

--- a/src/funcTest/groovy/com/github/kt3k/coveralls/PluginApplicationFunctionalTest.groovy
+++ b/src/funcTest/groovy/com/github/kt3k/coveralls/PluginApplicationFunctionalTest.groovy
@@ -1,0 +1,50 @@
+package com.github.kt3k.coveralls
+
+import org.junit.Assume
+import spock.lang.Unroll
+
+class PluginApplicationFunctionalTest extends AbstractFunctionalTest {
+    @Unroll
+    def "can apply the plugin #plugin with Gradle #version"() {
+        Assume.assumeTrue(version >= plugin.minimalGradleVersion)
+
+        buildFile << """
+            plugins {
+                id 'java-library'
+                ${plugin.pluginBlock}
+                id 'com.github.kt3k.coveralls'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                testImplementation 'junit:junit:4.13.2'
+            }
+
+            $plugin.config
+        """
+        file('src/main/java/com/acme').mkdirs()
+        file('src/main/java/com/acme/Foo.java') << """package com.acme;
+
+            class Foo {
+                static int magic() { return 42; }
+            }
+
+        """
+
+        when:
+        usingGradleVersion(version)
+        build(plugin.task, 'coveralls')
+
+        then:
+        noExceptionThrown()
+
+        where:
+        [plugin, version] << [
+            TESTED_COVERAGE_PLUGINS,
+            TESTED_GRADLE_VERSIONS
+        ].combinations()
+    }
+}

--- a/src/main/groovy/org/kt3k/gradle/plugin/coveralls/CoverallsTask.groovy
+++ b/src/main/groovy/org/kt3k/gradle/plugin/coveralls/CoverallsTask.groovy
@@ -7,9 +7,21 @@ import org.apache.http.entity.mime.MultipartEntityBuilder
 import org.gradle.api.DefaultTask
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.kt3k.gradle.plugin.CoverallsPluginExtension
-import org.kt3k.gradle.plugin.coveralls.domain.*
+import org.kt3k.gradle.plugin.coveralls.domain.CoberturaSourceReportFactory
+import org.kt3k.gradle.plugin.coveralls.domain.GitInfo
+import org.kt3k.gradle.plugin.coveralls.domain.GitInfoFactory
+import org.kt3k.gradle.plugin.coveralls.domain.JacocoSourceReportFactory
+import org.kt3k.gradle.plugin.coveralls.domain.PITSourceReportFactory
+import org.kt3k.gradle.plugin.coveralls.domain.ProxyInfoFactory
+import org.kt3k.gradle.plugin.coveralls.domain.Report
+import org.kt3k.gradle.plugin.coveralls.domain.ServiceInfo
+import org.kt3k.gradle.plugin.coveralls.domain.ServiceInfoFactory
+import org.kt3k.gradle.plugin.coveralls.domain.SourceReport
+import org.kt3k.gradle.plugin.coveralls.domain.SourceReportFactory
 
 import static groovyx.net.http.Method.POST
 
@@ -19,12 +31,15 @@ import static groovyx.net.http.Method.POST
 class CoverallsTask extends DefaultTask {
 
 	/** environmental variable */
+	@Input
 	Map<String, String> env = [:]
 
 	/** the logger */
+	@Internal
 	Logger logger = Logging.getLogger('coveralls-logger')
 
 	/** source report factory mapping */
+	@Internal
 	Map<String, SourceReportFactory> sourceReportFactoryMap = [:]
 
 


### PR DESCRIPTION
In Gradle 7, task properties which are not annotated with an input annotation becomes an error.

This PR adds the missing annotations and adds test coverage for multiple Gradle versions.
